### PR TITLE
Fix attachment handling for bulk license emails

### DIFF
--- a/src/components/hires/BulkUpdateDialog.tsx
+++ b/src/components/hires/BulkUpdateDialog.tsx
@@ -127,7 +127,10 @@ export function BulkUpdateDialog({
         department: hire.department,
         email: hire.email,
         title: hire.title,
-        microsoft_365_license: hire.microsoft_365_license || 'Standard'
+        microsoft_365_license: hire.microsoft_365_license || 'Standard',
+        // Include SRF document details so attachments can be sent
+        srf_document_path: hire.srf_document_path,
+        srf_document_name: hire.srf_document_name
       }));
       
       const result = await microsoftGraphService.sendLicenseRequestEmail({


### PR DESCRIPTION
## Summary
- include SRF document fields when mapping hires for bulk license email request

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685553095cbc8332b74e8ef4942ebd5a