### PR TITLE
Add AD signature placeholder

### DIFF
--- a/src/components/settings/MicrosoftGraphSettings.tsx
+++ b/src/components/settings/MicrosoftGraphSettings.tsx
@@ -54,8 +54,7 @@ Please process these license assignments at your earliest convenience. If you ne
 
 Thank you for your assistance.
 
-Best regards,
-HR Department`
+{{signature}}`
   });
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -432,7 +431,7 @@ HR Department`
                 placeholder="Use {{hireDetails}} to insert employee information"
               />
               <p className="text-xs text-muted-foreground">
-                Use {"{{hireDetails}}"} to insert formatted employee information and {"{{hireCount}}"} for count
+                Use {"{{hireDetails}}"} to insert formatted employee information, {"{{hireCount}}"} for count, and {"{{signature}}"} for the sender signature
               </p>
             </div>
 

--- a/src/server/data/settings.json
+++ b/src/server/data/settings.json
@@ -352,7 +352,7 @@
     "senderEmail": "widji.santoso@merdekabattery.com",
     "useLoggedInUserAsSender": false,
     "emailSubjectTemplate": "REQUEST PROSES LICENSE FOR {{hireCount}} NEW HIRE MTI - {{hireDate}}",
-    "emailBodyTemplate": "Dear IT Team,\n\nI hope this email finds you well. I am writing to request Microsoft 365 license assignments for the following new employees who have recently joined our organization:\n\n{{hireDetails}}\n\nPlease process these license assignments at your earliest convenience. If you need any additional information or have questions regarding these requests, please don't hesitate to contact me.\n\nThank you for your assistance.\n\nBest regards,\nMTI ICT Team",
+    "emailBodyTemplate": "Dear IT Team,\n\nI hope this email finds you well. I am writing to request Microsoft 365 license assignments for the following new employees who have recently joined our organization:\n\n{{hireDetails}}\n\nPlease process these license assignments at your earliest convenience. If you need any additional information or have questions regarding these requests, please don't hesitate to contact me.\n\nThank you for your assistance.\n\n{{signature}}",
     "lastConnectionTest": "2025-06-18T15:01:47.882Z"
   }
 }


### PR DESCRIPTION
## Summary
- add helper to fetch AD user info
- inject AD user signature into license emails
- document `{{signature}}` placeholder
- update default email template

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685558730670833290aa92a44606d8a3