### PR TITLE
Add AD sender email lookup

### DIFF
--- a/src/server/routes/active-directory.js
+++ b/src/server/routes/active-directory.js
@@ -1137,7 +1137,7 @@ export const getAdUserInfo = async (settings, username) => {
         const searchOptions = {
           filter: `(&(objectClass=user)(sAMAccountName=${safeUser}))`,
           scope: 'sub',
-          attributes: ['displayName', 'title', 'department']
+          attributes: ['displayName', 'title', 'department', 'mail']
         };
 
         client.search(settings.baseDN, searchOptions, (err, res) => {
@@ -1147,12 +1147,13 @@ export const getAdUserInfo = async (settings, username) => {
             return reject(err);
           }
 
-          let info = { displayName: '', title: '', department: '' };
+          let info = { displayName: '', title: '', department: '', mail: '' };
 
           res.on('searchEntry', (entry) => {
             info.displayName = entry.object.displayName || '';
             info.title = entry.object.title || '';
             info.department = entry.object.department || '';
+            info.mail = entry.object.mail || '';
           });
 
           res.on('error', (err) => {

--- a/src/server/routes/settings.js
+++ b/src/server/routes/settings.js
@@ -6,11 +6,13 @@ import { executeQuery } from '../utils/dbConnection.js';
 import sql from 'mssql';
 import { microsoftGraphService } from '../services/microsoftGraphService.js';
 import { getAdUserInfo } from './active-directory.js';
+import { resolveSenderEmail } from '../utils/emailUtils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const router = express.Router();
+
 
 // Data storage paths
 const DATA_DIR = path.join(__dirname, '../data');
@@ -774,12 +776,11 @@ router.post('/microsoft-graph/send-license-request', async (req, res) => {
       .join(''); // Join without extra spacing
 
     // Determine sender email
-    let senderEmail = graphSettings.senderEmail;
-    if (graphSettings.useLoggedInUserAsSender) {
-      // TODO: Get logged-in user's email from session/token
-      // For now, fall back to settings sender email
-      senderEmail = graphSettings.senderEmail;
-    }
+    const senderEmail = await resolveSenderEmail(
+      graphSettings,
+      adSettings,
+      req
+    );
 
     const emailData = {
       recipients: finalToRecipients,

--- a/src/server/utils/emailUtils.js
+++ b/src/server/utils/emailUtils.js
@@ -1,0 +1,24 @@
+export const resolveSenderEmail = async (
+  graphSettings,
+  adSettings,
+  req,
+  getInfo
+) => {
+  let senderEmail = graphSettings.senderEmail;
+  if (
+    graphSettings.useLoggedInUserAsSender &&
+    req?.user?.username &&
+    adSettings?.enabled &&
+    typeof getInfo === 'function'
+  ) {
+    try {
+      const info = await getInfo(adSettings, req.user.username);
+      if (info?.mail) {
+        senderEmail = info.mail;
+      }
+    } catch (err) {
+      console.error('Failed to fetch sender email from AD:', err);
+    }
+  }
+  return senderEmail;
+};

--- a/tests/resolveSenderEmail.test.js
+++ b/tests/resolveSenderEmail.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveSenderEmail } from '../src/server/utils/emailUtils.js';
+
+const defaultEmail = 'default@example.com';
+const graphBase = { senderEmail: defaultEmail, useLoggedInUserAsSender: false };
+const adSettings = { enabled: true };
+
+// helper stub
+const stubInfo = mail => async () => ({ mail });
+
+test('returns default sender when feature disabled', async () => {
+  const req = { user: { username: 'jdoe' } };
+  const email = await resolveSenderEmail(graphBase, adSettings, req, stubInfo('user@example.com'));
+  assert.equal(email, defaultEmail);
+});
+
+test('returns AD email when enabled and lookup succeeds', async () => {
+  const req = { user: { username: 'jdoe' } };
+  const graph = { ...graphBase, useLoggedInUserAsSender: true };
+  const email = await resolveSenderEmail(graph, adSettings, req, stubInfo('user@example.com'));
+  assert.equal(email, 'user@example.com');
+});
+
+test('falls back to default when lookup fails', async () => {
+  const req = { user: { username: 'jdoe' } };
+  const graph = { ...graphBase, useLoggedInUserAsSender: true };
+  const failing = async () => { throw new Error('lookup error'); };
+  const email = await resolveSenderEmail(graph, adSettings, req, failing);
+  assert.equal(email, defaultEmail);
+});


### PR DESCRIPTION
## Summary
- fetch user mail in AD queries
- determine sender email based on logged in user
- add helper and accompanying unit tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node --test tests/resolveSenderEmail.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68555a88595883329088fd42b2c472f2