### PR TITLE
Add missing AD user info warning

### DIFF
--- a/src/server/routes/active-directory.js
+++ b/src/server/routes/active-directory.js
@@ -1164,6 +1164,9 @@ export const getAdUserInfo = async (settings, username) => {
 
           res.on('end', () => {
             client.unbind();
+            if (!info.displayName && !info.title && !info.department) {
+              logger.api.warn('No AD info found for', username);
+            }
             resolve(info);
           });
         });


### PR DESCRIPTION
## Summary
- log a warning if AD lookup returns no user details

## Testing
- `node --test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855672d60c8833287dcc931b89f9dfb