### PR TITLE
Improve AD search filter for UPN/email

### DIFF
--- a/src/server/routes/active-directory.js
+++ b/src/server/routes/active-directory.js
@@ -1134,8 +1134,18 @@ export const getAdUserInfo = async (settings, username) => {
         }
 
         const safeUser = escapeLdapFilterValue(username);
+        let searchFilter = `(&(objectClass=user)(sAMAccountName=${safeUser}))`;
+        if (username.includes('@')) {
+          const userPart = username.split('@')[0];
+          const safeUserPart = escapeLdapFilterValue(userPart);
+          searchFilter =
+            `(&(objectClass=user)(|(sAMAccountName=${safeUserPart})(userPrincipalName=${safeUser})(mail=${safeUser})))`;
+        }
+
+        logger.api.debug(`User info search filter: ${searchFilter}`);
+
         const searchOptions = {
-          filter: `(&(objectClass=user)(sAMAccountName=${safeUser}))`,
+          filter: searchFilter,
           scope: 'sub',
           attributes: ['displayName', 'title', 'department', 'mail']
         };


### PR DESCRIPTION
## Summary
- expand `getAdUserInfo` to support UPN or email lookups
- log the effective LDAP filter for debugging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68556914f780833290b22cb0489c54b8