### PR TITLE
Add contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository Guidelines
+
+This repository uses Node.js with TypeScript.
+
+## Common Commands
+
+- `npm install` – install dependencies.
+- `npm run lint` – run ESLint to check code style.
+- `npm test` – currently undefined; there is no test script in `package.json`.
+
+## Style Guidelines
+
+- Use **two spaces** for indentation and include semicolons.
+- Run `npm run lint` before committing and resolve any issues.
+
+## Commit Guidelines
+
+- Write short, present-tense commit messages.
+- Prefix with a type when relevant (`feat:`, `fix:`, `chore:` etc.).
+- Keep the first line under 72 characters.


### PR DESCRIPTION
## Summary
- add a new `AGENTS.md` describing common commands and contributor guidelines

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails to find '@eslint/js')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68556d0aea6483328d0e7c68589e8341