### PR TITLE
Add LDAP query test

### DIFF
--- a/tests/ldapQuery.test.js
+++ b/tests/ldapQuery.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { search } from '../src/server/lib/ldapService.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const settingsPath = path.join(__dirname, '../src/server/data/settings.json');
+const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+const baseDN = settings.activeDirectorySettings.baseDN;
+
+const filter = '(&(objectClass=user)(sAMAccountName=*widji.santoso*))';
+
+test('ldap query returns entries', async () => {
+  const entries = await search(baseDN, filter, ['sAMAccountName', 'displayName']);
+  console.log(entries);
+  assert.ok(Array.isArray(entries));
+});


### PR DESCRIPTION
## Summary
- add ldapQuery.test.js under tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6855d5e47cc88332afba618e1c2f24af