### PR TITLE
Fix logged-in sender email bug

### DIFF
--- a/src/server/services/microsoftGraphService.js
+++ b/src/server/services/microsoftGraphService.js
@@ -94,7 +94,9 @@ class MicrosoftGraphService {
       const graphClient = await this.initializeGraphClient(settings);
 
       // Determine sender email
-      let senderEmail = settings.senderEmail;
+      // Prefer sender provided in emailData (e.g., from logged-in user)
+      let senderEmail = emailData.senderEmail || settings.senderEmail;
+
       if (!senderEmail && settings.username && this.isValidEmail(settings.username)) {
         senderEmail = settings.username;
       }


### PR DESCRIPTION
## Summary
- allow emailData.senderEmail to override settings sender

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685613275abc8332838d53a7e3f89fb6